### PR TITLE
Add old service background switch

### DIFF
--- a/app/src/main/java/com/c3r5b8/telegram_monet/MainActivity.kt
+++ b/app/src/main/java/com/c3r5b8/telegram_monet/MainActivity.kt
@@ -26,6 +26,7 @@ class MainActivity : AppCompatActivity() {
         val buttonTelegramLight: Button = findViewById(R.id.setup_light_button)
         val useGradient: SwitchCompat = findViewById(R.id.switchGradient)
         val useGradientAvatars: SwitchCompat = findViewById(R.id.switchGradientAvatars)
+        val useOldServiceBackground: SwitchCompat = findViewById(R.id.switchOldServiceBackground)
 
         //Buttons TelegramX
         val buttonTelegramXDark: Button = findViewById(R.id.setup_x_dark_button)
@@ -63,6 +64,10 @@ class MainActivity : AppCompatActivity() {
                 darkThemeImport = darkThemeImport.replace("avatar_backgroundRed=n2_800", "avatar_backgroundRed=n2_700")
                 darkThemeImport = darkThemeImport.replace("avatar_backgroundSaved=n2_800", "avatar_backgroundSaved=n2_700")
                 darkThemeImport = darkThemeImport.replace("avatar_backgroundViolet=n2_800", "avatar_backgroundViolet=n2_700")
+            }
+
+            if(useOldServiceBackground.isChecked) {
+                darkThemeImport = darkThemeImport.replace("chat_serviceBackground=n1_700", "chat_serviceBackground=n2_800")
             }
 
             val themeString = changeTextTelegram(darkThemeImport, applicationContext)
@@ -183,10 +188,12 @@ class MainActivity : AppCompatActivity() {
 
         val useGradient: SwitchCompat = findViewById(R.id.switchGradient)
         val useGradientAvatars: SwitchCompat = findViewById(R.id.switchGradientAvatars)
+        val useOldServiceBackground: SwitchCompat = findViewById(R.id.switchOldServiceBackground)
         val isAmoledMode: SwitchCompat = findViewById(R.id.switchAmoledPhone)
 
         sharedPreferencesEditor.putBoolean("useGradient", useGradient.isChecked)
         sharedPreferencesEditor.putBoolean("useGradientAvatars", useGradientAvatars.isChecked)
+        sharedPreferencesEditor.putBoolean("useOldServiceBackground", useOldServiceBackground.isChecked)
         sharedPreferencesEditor.putBoolean("isAmoledMode", isAmoledMode.isChecked)
         sharedPreferencesEditor.apply()
     }
@@ -197,10 +204,12 @@ class MainActivity : AppCompatActivity() {
 
         val useGradient: SwitchCompat = findViewById(R.id.switchGradient)
         val useGradientAvatars: SwitchCompat = findViewById(R.id.switchGradientAvatars)
+        val useOldServiceBackground: SwitchCompat = findViewById(R.id.switchOldServiceBackground)
         val isAmoledMode: SwitchCompat = findViewById(R.id.switchAmoledPhone)
 
         useGradient.isChecked = sharedPreferences.getBoolean("useGradient", false)
         useGradientAvatars.isChecked = sharedPreferences.getBoolean("useGradientAvatars", false)
+        useOldServiceBackground.isChecked = sharedPreferences.getBoolean("useOldServiceBackground", false)
         isAmoledMode.isChecked = sharedPreferences.getBoolean("isAmoledMode", false)
     }
 

--- a/app/src/main/res/layout/settings_card.xml
+++ b/app/src/main/res/layout/settings_card.xml
@@ -76,6 +76,17 @@
                 android:fontFamily="@font/google_sans_medium"
                 android:text="@string/settings_card_use_gradient_avatars"
                 android:textSize="16sp" />
+            
+            <com.google.android.material.materialswitch.MaterialSwitch
+                style="@style/Widget.Material3.CompoundButton.MaterialSwitch"
+                android:id="@+id/switchOldServiceBackground"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_gravity="end"
+                android:layout_margin="5dp"
+                android:fontFamily="@font/google_sans_medium"
+                android:text="@string/settings_card_use_old_service_background"
+                android:textSize="16sp" />
 
 
         </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,5 @@
     <string name="settings_card_title">Settings</string>
     <string name="settings_card_use_gradient">Enable gradient (Telegram)</string>
     <string name="settings_card_use_gradient_avatars">Enable gradient for avatars</string>
+    <string name="settings_card_use_old_service_background">Enable old service background</string>
 </resources>


### PR DESCRIPTION
I don't like the new accent for chat_serviceBackground that was changed in 9.1.4, it stands out too much. I know this was done because of the reactions on the stickers, but for me the overall look is more important than the reactions, so it would be nice to make it switchable too.
<details>
<summary>New</summary>

[![New][1]][1]

[1]: https://user-images.githubusercontent.com/58901923/232319383-1b753115-cd36-4a23-bc32-8f31cc14a00a.jpg

</details>
<details>
<summary>Old</summary>

[![Old][2]][2]

[2]: https://user-images.githubusercontent.com/58901923/232319387-c40b259e-a689-4e3e-8b3a-62984e5aeb4e.jpg

</details>